### PR TITLE
Fixed 'useBits' erroring and pass transaction object to callback

### DIFF
--- a/src/modules/bits/actions.js
+++ b/src/modules/bits/actions.js
@@ -9,9 +9,9 @@ export default {
         })
     },
     onTransactionComplete({dispatch}, callback) {
-        window.Twitch.ext.bits.onTransactionComplete(() => {
+        window.Twitch.ext.bits.onTransactionComplete((transaction) => {
             dispatch('setHasOngoingBitTransaction', false)
-            callback();
+            callback(transaction);
         })
     },
     setUseLoopBack({}, setUseLoopBack) {
@@ -20,7 +20,7 @@ export default {
     showBitsBalance() {
         window.Twitch.ext.bits.showBitsBalance();
     },
-    useBits({}, sku) {
+    useBits({dispatch}, sku) {
         dispatch('setHasOngoingBitTransaction', true)
         window.Twitch.ext.bits.useBits(sku);
     },


### PR DESCRIPTION
This pull request fixes two issues I've found when using this helper.
When trying to use the bits functions the 'useBits' throws an error, this fixes that.
The transaction complete callback receives an object with data shown in the [docs](https://dev.twitch.tv/docs/extensions/reference#helper-bits)